### PR TITLE
issue-2473 - Set 404 code in case if response returning null

### DIFF
--- a/src/Plugin/Add404CodeToEmptyResponsePlugin.php
+++ b/src/Plugin/Add404CodeToEmptyResponsePlugin.php
@@ -14,6 +14,7 @@ use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\Response\HttpInterface;
 use Magento\Framework\Interception\InterceptorInterface;
 use Magento\Framework\Serialize\Serializer\Json;
+use Magento\TestFramework\Inspection\Exception;
 
 class Add404CodeToEmptyResponsePlugin
 {
@@ -45,6 +46,10 @@ class Add404CodeToEmptyResponsePlugin
         }
 
         $responseContent = $this->json->unserialize($response->getBody());
+
+        if(!key_exists('data', $responseContent)) {
+            return $response;
+        }
 
         /*
          * In case if response returns object with empty data

--- a/src/Plugin/Add404CodeToEmptyResponsePlugin.php
+++ b/src/Plugin/Add404CodeToEmptyResponsePlugin.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * ScandiPWA_Cache
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_Cache
+ * @author      Aleksandrs Kondratjevs <Aleksandrs.Kondratjevs@scandiweb.com | info@scandiweb.com>
+ * @copyright   Copyright (c) 2021 Scandiweb, Ltd (https://scandiweb.com)
+ */
+
+namespace Scandipwa\Cache\Plugin;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\Response\HttpInterface;
+use Magento\Framework\Interception\InterceptorInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+
+class Add404CodeToEmptyResponsePlugin
+{
+    /**
+     * @var Json
+     */
+    protected $json;
+
+    /**
+     * Add404CodeToEmptyResponsePlugin constructor.
+     * @param Json $json
+     */
+    public function __construct(
+        Json $json
+    ) {
+        $this->json = $json;
+    }
+
+    /**
+     * @param InterceptorInterface $interceptor
+     * @param HttpInterface $response
+     * @param RequestInterface $request
+     * @return HttpInterface
+     */
+    public function afterDispatch(InterceptorInterface $interceptor, HttpInterface $response, RequestInterface $request)
+    {
+        if (!array_key_exists('hash', $request->getParams())) {
+            return $response;
+        }
+
+        $responseContent = $this->json->unserialize($response->getBody());
+
+        /*
+         * In case if response returns object with empty data
+         * set 404 code to response witch will prevent it from caching
+         */
+        if (
+            empty(current($responseContent['data']))
+            || empty(current(current($responseContent['data'])))
+        ) {
+            return $response->setStatusHeader(404);
+        }
+
+        return $response;
+    }
+}
+

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -8,12 +8,16 @@
  *
  * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
  */
---><config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\GraphQl\Controller\GraphQl">
         <plugin name="scandipwa_persisted_cache" type="ScandiPWA\Cache\Plugin\AddTagsToResponsePlugin"/>
     </type>
     <type name="ScandiPWA\GraphQl\Controller\GraphQl">
         <plugin name="scandipwa_persisted_cache" type="ScandiPWA\Cache\Plugin\AddTagsToResponsePlugin"/>
+    </type>
+    <type name="Magento\GraphQl\Controller\GraphQl">
+        <plugin name="scandipwa_404_return" type="ScandiPWA\Cache\Plugin\Add404CodeToEmptyResponsePlugin"/>
     </type>
     <preference for="ScandiPWA\Cache\Model\CacheInterface" type="ScandiPWA\Cache\Model\Cache" />
 </config>

--- a/src/etc/events.xml
+++ b/src/etc/events.xml
@@ -8,7 +8,8 @@
  *
  * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
  */
---><config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="magento_catalog_api_data_categoryinterface_load_after">
         <observer name="pq_cc_category" instance="ScandiPWA\Cache\Observer\Response\TagEntityResponse"/>
     </event>

--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -8,7 +8,8 @@
  *
  * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
  */
---><config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
     <module name="ScandiPWA_Cache">
         <sequence>
             <module name="Magento_GraphQl"/>


### PR DESCRIPTION
Fixes scandipwa/scandipwa#2473 

Related: https://github.com/scandipwa/urlrewrite-graphql/pull/7

In some cases response can bring us null result which is expected, but this response has no tag and it is cached. For this reason we can set 404 code to response if brings null data so it won't be cached.