### PR TITLE
Find an entity by general key

### DIFF
--- a/src/Observer/FlushVarnishObserver.php
+++ b/src/Observer/FlushVarnishObserver.php
@@ -35,7 +35,7 @@ class FlushVarnishObserver implements ObserverInterface
      */
     public function execute(Observer $observer)
     {
-        $entity = $observer->getEntity() ?? $observer->getDataByKey('object');
+        $entity = $observer->getEntity() ?? $observer->getDataByKey('data_object');
         $identities = $entity->getIdentities();
         $this->purgeCache->sendPurgeRequest(implode(',', $identities));
     }


### PR DESCRIPTION
A 3rd party extension may override **_eventObject**. In this case, will have the `$entity = null` inside **FlushVarnishObserver.php** `execute()` function even with correct events and `getIdentities()` method.

I propose using general key `data_object` for such case. Magento 2 **AbstractModel.php** source:
```php
/**
     * Get array of objects transferred to default events processing
     *
     * @return array
     */
    protected function _getEventData()
    {
        return [
            'data_object' => $this,
            $this->_eventObject => $this,
        ];
    }
```
Fixes https://github.com/scandipwa/scandipwa/issues/4266